### PR TITLE
해외승인 개발

### DIFF
--- a/src/main/java/com/kenny/customhandleradaptorpoc/approval/controller/dto/해외승인DTO.java
+++ b/src/main/java/com/kenny/customhandleradaptorpoc/approval/controller/dto/해외승인DTO.java
@@ -1,0 +1,47 @@
+package com.kenny.customhandleradaptorpoc.approval.controller.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+public class 해외승인DTO {
+
+    public static class 승인 {
+
+        @Getter
+        @Builder
+        @ToString
+        public static class In {
+            private final String 국가코드;
+            private final String 승인번호;
+            private final String 카드번호;
+            private final String 승인금액;
+            private final String 통화코드;
+        }
+
+        @Getter
+        @Builder
+        @ToString
+        public static class Out {
+            private final String 결과코드;
+        }
+    }
+
+    public static class 취소 {
+
+        @Getter
+        @Builder
+        @ToString
+        public static class In {
+            private final String 국가코드;
+            private final String 승인번호;
+        }
+
+        @Getter
+        @Builder
+        @ToString
+        public static class Out {
+            private final String 결과코드;
+        }
+    }
+}

--- a/src/main/java/com/kenny/customhandleradaptorpoc/approval/controller/해외승인Controller.java
+++ b/src/main/java/com/kenny/customhandleradaptorpoc/approval/controller/해외승인Controller.java
@@ -1,0 +1,25 @@
+package com.kenny.customhandleradaptorpoc.approval.controller;
+
+import com.kenny.customhandleradaptorpoc.approval.controller.dto.해외승인DTO;
+import com.kenny.customhandleradaptorpoc.approval.service.해외승인Service;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class 해외승인Controller {
+
+    private final 해외승인Service overseaApprovalServce;
+
+    @PostMapping("/approval/oversea")
+    public 해외승인DTO.승인.Out process해외승인( @RequestBody final 해외승인DTO.승인.In input ) {
+        log.debug( "# 해외승인Service process해외승인 : {}", input.toString());
+        return 해외승인DTO.승인.Out.builder()
+                .결과코드("OK")
+                .build();
+    }
+}

--- a/src/main/java/com/kenny/customhandleradaptorpoc/approval/service/해외승인Service.java
+++ b/src/main/java/com/kenny/customhandleradaptorpoc/approval/service/해외승인Service.java
@@ -1,0 +1,17 @@
+package com.kenny.customhandleradaptorpoc.approval.service;
+
+import com.kenny.customhandleradaptorpoc.approval.controller.dto.해외승인DTO;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class 해외승인Service {
+
+    public 해외승인DTO.승인.Out process해외승인(final 해외승인DTO.승인.In input ) {
+        log.debug( "# 해외승인Service process해외승인 : {}", input.toString());
+        return 해외승인DTO.승인.Out.builder()
+                .결과코드("OK")
+                .build();
+    }
+}


### PR DESCRIPTION
## What? 
- 해외승인 개발
- issue : REQ-3

## Why?
- 국내, 해외, 승인, 승인취소별로 API를 구분하기 위해 그 중 해외승인을 개발한 건

## How?
- 일반적인 Layer Architecture 구조로 개발함
- 해외승인 로직을 담당하는 Controller, Service 클래스를 생성하고 승인 메서드를 구분해서 개발했음

## Testing?
- N/A

## Anything else?
- N/A