### PR TITLE
feat: Handler를 이용한 승인API 라우팅, HttpServletRequest Wrapper, ServletFilt…

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -26,6 +26,8 @@
 **비기능 요건**
 1. [REQ-5] byte[]를 payload로 받는 1개의 API를 HandlerAdaptor를 통해, 국내승인 / 국내승인취소 등의 API로 routing 한다.
    - byte[]의 첫번째 3자리가 국내승인, 국내승인취소 등을 구분하는 구분자다.
+2. [REQ-6] HttpServletRequest의 inputStream을 여러번 사용하기 위해, 이를 wrapping하는 클래스를 만든다.
+3. [REQ-7] ServletFilter에서 HttpServletRequest를 REQ-6번의 Wrapper로 감싼다.
 
 ---
 
@@ -38,3 +40,6 @@
 ---
 
 ## Reference Materials
+- [Spring MVC의 Request Flow 정리](https://hyos-dev-log.tistory.com/m/21)
+- [Spring(2) Spring Web MVC](https://velog.io/@hanblueblue/%EB%B2%88%EC%97%AD-Spring2-Spring-Web-MVC)
+- [Spring MVC HandlerAdapter 분석하기](https://velog.io/@jihoson94/Spring-MVC-HandlerAdapter-%EB%B6%84%EC%84%9D%ED%95%98%EA%B8%B0)

--- a/build.gradle
+++ b/build.gradle
@@ -23,8 +23,14 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    // 스트림을 문자열로 변환하기 위해 사용
+    implementation 'commons-io:commons-io:2.14.0'
+    // String to JSON을 하기 위해 사용
+    implementation 'com.konghq:unirest-objectmapper-jackson:4.0.10'
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/src/main/java/com/kenny/customhandleradaptorpoc/approval/controller/dto/국내승인DTO.java
+++ b/src/main/java/com/kenny/customhandleradaptorpoc/approval/controller/dto/국내승인DTO.java
@@ -4,8 +4,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
 
-import java.math.BigDecimal;
-
 public class 국내승인DTO {
 
     public static class 승인 {

--- a/src/main/java/com/kenny/customhandleradaptorpoc/approval/controller/국내승인Controller.java
+++ b/src/main/java/com/kenny/customhandleradaptorpoc/approval/controller/국내승인Controller.java
@@ -13,6 +13,8 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 public class 국내승인Controller {
 
+    public static final String BEAN_NAME = "국내승인Controller";
+
     private final 국내승인Service domesticApprovalService;
 
     @PostMapping("/approval/domestic")
@@ -22,8 +24,8 @@ public class 국내승인Controller {
     }
 
     @PostMapping("/approval/domestic/cancle")
-    public 국내승인DTO.취소.Out process국내취소( @RequestBody final 국내승인DTO.취소.In input ) {
-        log.debug("# 국내승인Controller process국내취소 : {}", input.toString());
+    public 국내승인DTO.취소.Out process국내승인취소(@RequestBody final 국내승인DTO.취소.In input ) {
+        log.debug("# 국내승인Controller process국내승인취소 : {}", input.toString());
         return domesticApprovalService.process국내승인취소(input);
     }
 }

--- a/src/main/java/com/kenny/customhandleradaptorpoc/approval/controller/해외승인Controller.java
+++ b/src/main/java/com/kenny/customhandleradaptorpoc/approval/controller/해외승인Controller.java
@@ -13,6 +13,8 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 public class 해외승인Controller {
 
+    public static final String BEAN_NAME = "해외승인Controller";
+
     private final 해외승인Service overseaApprovalServce;
 
     @PostMapping("/approval/oversea")

--- a/src/main/java/com/kenny/customhandleradaptorpoc/approval/service/국내승인Service.java
+++ b/src/main/java/com/kenny/customhandleradaptorpoc/approval/service/국내승인Service.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Service;
 public class 국내승인Service {
 
     public 국내승인DTO.승인.Out process국내승인( final 국내승인DTO.승인.In input ) {
-        log.debug( "# 국내승인Service process국내승인 : {}", input.toString() );
+        log.warn( "# 국내승인Service process국내승인 : {}", input.toString() );
 
         return 국내승인DTO.승인.Out.builder()
                 .결과코드("OK")
@@ -17,7 +17,7 @@ public class 국내승인Service {
     }
 
     public 국내승인DTO.취소.Out process국내승인취소( final 국내승인DTO.취소.In input ) {
-        log.debug( "# 국내승인Service process국내승인 : {}", input.toString() );
+        log.warn( "# 국내승인Service process국내승인 : {}", input.toString() );
 
         return 국내승인DTO.취소.Out.builder()
                 .결과코드("OK")

--- a/src/main/java/com/kenny/customhandleradaptorpoc/config/WebConfig.java
+++ b/src/main/java/com/kenny/customhandleradaptorpoc/config/WebConfig.java
@@ -1,0 +1,46 @@
+package com.kenny.customhandleradaptorpoc.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kenny.customhandleradaptorpoc.filter.CachingRequestBodyFilter;
+import com.kenny.customhandleradaptorpoc.handler.승인HandlerAdapter;
+import com.kenny.customhandleradaptorpoc.handler.승인HandlerMapping;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+@Slf4j
+public class WebConfig {
+
+    private final ApplicationContext applicationContext;
+    private final ObjectMapper objectMapper;
+    private final CachingRequestBodyFilter cachingRequestBodyFilter;
+
+    @Bean
+    public 승인HandlerMapping handlerMapping() {
+        log.warn("# WebConfig 승인HandlerMapping Bean 등록");
+
+        return new 승인HandlerMapping(applicationContext);
+    }
+
+    @Bean
+    public 승인HandlerAdapter handlerAdapter() {
+        log.warn("# WebConfig 승인HandlerAdapter Bean 등록");
+
+        return new 승인HandlerAdapter(objectMapper);
+    }
+
+    @Bean
+    public FilterRegistrationBean<CachingRequestBodyFilter> requestFilter() {
+        log.warn("# WebConfig CachingRequestBodyFilter Bean 등록");
+
+        final FilterRegistrationBean<CachingRequestBodyFilter> registrationBean = new FilterRegistrationBean<>();
+        registrationBean.setFilter(cachingRequestBodyFilter);
+        registrationBean.addUrlPatterns("/*");
+        return registrationBean;
+    }
+}

--- a/src/main/java/com/kenny/customhandleradaptorpoc/filter/CachedBodyHttpServletRequest.java
+++ b/src/main/java/com/kenny/customhandleradaptorpoc/filter/CachedBodyHttpServletRequest.java
@@ -1,0 +1,59 @@
+package com.kenny.customhandleradaptorpoc.filter;
+
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import org.springframework.util.StreamUtils;
+
+import java.io.*;
+
+public class CachedBodyHttpServletRequest extends HttpServletRequestWrapper {
+
+    private byte[] cachedBody;
+
+    public CachedBodyHttpServletRequest( HttpServletRequest request ) throws IOException {
+        super(request);
+        final InputStream requestInputStream = request.getInputStream();
+        this.cachedBody = StreamUtils.copyToByteArray(requestInputStream);
+    }
+
+    @Override
+    public ServletInputStream getInputStream() throws IOException {
+        return new CachedBodyServletInputStream(this.cachedBody);
+    }
+
+    @Override
+    public BufferedReader getReader() throws IOException {
+        final ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(this.cachedBody);
+        return new BufferedReader(new InputStreamReader(byteArrayInputStream));
+    }
+
+    private static class CachedBodyServletInputStream extends ServletInputStream {
+        private ByteArrayInputStream byteArrayInputStream;
+
+        public CachedBodyServletInputStream(byte[] cachedBody) {
+            this.byteArrayInputStream = new ByteArrayInputStream(cachedBody);
+        }
+
+        @Override
+        public int read() throws IOException {
+            return byteArrayInputStream.read();
+        }
+
+        @Override
+        public boolean isFinished() {
+            return byteArrayInputStream.available() == 0;
+        }
+
+        @Override
+        public boolean isReady() {
+            return true;
+        }
+
+        @Override
+        public void setReadListener(final ReadListener listener) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/src/main/java/com/kenny/customhandleradaptorpoc/filter/CachingRequestBodyFilter.java
+++ b/src/main/java/com/kenny/customhandleradaptorpoc/filter/CachingRequestBodyFilter.java
@@ -1,0 +1,20 @@
+package com.kenny.customhandleradaptorpoc.filter;
+
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@Slf4j
+public class CachingRequestBodyFilter implements Filter {
+    @Override
+    public void doFilter(final ServletRequest request, final ServletResponse response, final FilterChain chain) throws IOException, ServletException {
+        log.warn("# CachingRequestBodyFilter doFilter()");
+
+        final CachedBodyHttpServletRequest wrappedRequest = new CachedBodyHttpServletRequest((HttpServletRequest) request);
+        chain.doFilter(wrappedRequest, response);
+    }
+}

--- a/src/main/java/com/kenny/customhandleradaptorpoc/handler/승인HandlerAdapter.java
+++ b/src/main/java/com/kenny/customhandleradaptorpoc/handler/승인HandlerAdapter.java
@@ -1,0 +1,88 @@
+package com.kenny.customhandleradaptorpoc.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kenny.customhandleradaptorpoc.approval.controller.dto.국내승인DTO;
+import com.kenny.customhandleradaptorpoc.approval.controller.dto.해외승인DTO;
+import com.kenny.customhandleradaptorpoc.approval.controller.국내승인Controller;
+import com.kenny.customhandleradaptorpoc.approval.controller.해외승인Controller;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.IOUtils;
+import org.springframework.core.Ordered;
+import org.springframework.http.MediaType;
+import org.springframework.web.servlet.HandlerAdapter;
+import org.springframework.web.servlet.ModelAndView;
+
+import java.nio.charset.StandardCharsets;
+
+@RequiredArgsConstructor
+@Slf4j
+public class 승인HandlerAdapter implements HandlerAdapter, Ordered {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public boolean supports(final Object handler) {
+        return handler instanceof 국내승인Controller || handler instanceof 해외승인Controller;
+    }
+
+    @Override
+    public ModelAndView handle(final HttpServletRequest request, final HttpServletResponse response, final Object handler) throws Exception {
+
+        final byte[] body = IOUtils.toByteArray(request.getInputStream());
+        final String bodyString = IOUtils.toString(request.getReader());
+
+        final String prefix = new String(body, 0, 3);
+        final String amount = new String(body, 3, 5);
+
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        switch ( prefix ) {
+            case "100" -> {
+                final 국내승인DTO.승인.Out output = ((국내승인Controller) handler).process국내승인(국내승인DTO.승인.In.builder()
+                        .승인금액(amount)
+                        .build());
+
+                final String outputJson = objectMapper.writeValueAsString(output);
+                response.getWriter().write(outputJson);
+            }
+            case "101" -> {
+                final 국내승인DTO.취소.Out output = ((국내승인Controller) handler).process국내승인취소(국내승인DTO.취소.In.builder()
+                        .build());
+
+                final String outputJson = objectMapper.writeValueAsString(output);
+                response.getWriter().write(outputJson);
+            }
+            case "200" -> {
+                final 해외승인DTO.승인.Out output = ((해외승인Controller) handler).process해외승인(해외승인DTO.승인.In.builder()
+                        .승인금액(amount)
+                        .build());
+
+                final String outputJson = objectMapper.writeValueAsString(output);
+                response.getWriter().write(outputJson);
+            }
+            case "201" -> {
+                final 해외승인DTO.취소.Out output = ((해외승인Controller) handler).process해외승인취소(해외승인DTO.취소.In.builder()
+                        .build());
+
+                final String outputJson = objectMapper.writeValueAsString(output);
+                response.getWriter().write(outputJson);
+            }
+        }
+
+        return null;
+    }
+
+    @Override
+    public long getLastModified(final HttpServletRequest request, final Object handler) {
+        return -1;
+    }
+
+    @Override
+    public int getOrder() {
+        return 0;   // 0 is higher priority than, for example, 1 or 10
+    }
+}

--- a/src/main/java/com/kenny/customhandleradaptorpoc/handler/승인HandlerMapping.java
+++ b/src/main/java/com/kenny/customhandleradaptorpoc/handler/승인HandlerMapping.java
@@ -1,0 +1,46 @@
+package com.kenny.customhandleradaptorpoc.handler;
+
+import com.kenny.customhandleradaptorpoc.approval.controller.국내승인Controller;
+import com.kenny.customhandleradaptorpoc.approval.controller.해외승인Controller;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.IOUtils;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.Ordered;
+import org.springframework.web.servlet.HandlerExecutionChain;
+import org.springframework.web.servlet.HandlerMapping;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+@Slf4j
+public class 승인HandlerMapping implements HandlerMapping, Ordered {
+
+    private final ApplicationContext applicationContext;
+    private final String APPROVAL_API_URI_PATH = "/approval";
+
+    @Override
+    public HandlerExecutionChain getHandler(final HttpServletRequest request) throws IOException {
+        log.warn("# 승인HandlerMapping getHandler()");
+
+        final byte[] body = IOUtils.toByteArray(request.getInputStream());
+        final String bodyString = IOUtils.toString(request.getReader());
+
+        final String prefix = new String(body, 0, 3);
+
+        if ( APPROVAL_API_URI_PATH.equals(request.getRequestURI()) && ( "100".equals(prefix) || "101".equals(prefix) ) ) {
+            return new HandlerExecutionChain(applicationContext.getBean( 국내승인Controller.BEAN_NAME ));
+
+        } else if ( APPROVAL_API_URI_PATH.equals(request.getRequestURI()) && ( "200".equals(prefix) || "201".equals(prefix) ) ) {
+            return new HandlerExecutionChain(applicationContext.getBean( 해외승인Controller.BEAN_NAME ));
+        }
+
+        return null;
+    }
+
+    @Override
+    public int getOrder() {
+        return 0;   // 0 is higher priority than, for example, 1 or 10
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,1 +1,4 @@
-
+logging:
+  level:
+    root: info
+    com.kenny.customhandleradaptorpoc: debug


### PR DESCRIPTION
## What? 
1. 국내승인, 해외승인을 routing하기 위한 커스텀 HandlerMapping, HandlerAdapter 개발
2. 요청본문의 byte[]를 여러번 사용하기 위한 Wrapping 클래스 개발
3. 2번의 Wrapping 클래스로 ServletFilter에서 HttpServletRequest를 랩핑하는 로직 개발
4. 로그레벨 조정
- issue : REQ-5, REQ-6, REQ-7

## Why?
1. 승인API는 1개의 URI로 4개의 기능을 수행함
    - 이에, HandlerMapping과 HandlerAdapter에서 payload를 보고 각각의 기능을 하는 Controller Method를 호출함
    - 이로써, Controller에서는 단일책임을 구현하는 Method를 각각 4개를 분리해서 구현할 수 있고, 클라이언트에서 직접 이 API들을 호출한것과 같은 효과를 이룰 수 있음
2. HttpServletRequest는 한번 getInputStream() 혹은 getReader()를 하면 그 내용이 소모됨. Filter, Handler, Interceptor에서 request를 활용하기 위해서 Wrapper 클래스를 개발했음
3. HttpServletRequest를 Wrapping 하는 클래스를 생성하고 대체하기 위해서 ServletFilter를 개발했음

## How?
1. 승인HandlerMapping
    - HandlerMapping을 구현함
    - getHandler()에서 매핑되는 핸들러( Controller )를 지정하여 체인에 담아 리턴함
3. 승인HandlerAdapter
    - HandlerAdapter를 구현함
    - handle()에서 Controller의 Method를 호출함
4. CachedBodyHttpServletRequset
    - 인스턴스 변수로 byte[]를 두고 여기에 request 본문을 보관함
5. CachingRequestBodyFilter
    - Filter를 구현함
6. WebConfig
    - HandlerMapping, HandlerAdapter Bean 등록
    - FilterRegistrationBean 등록 

## Testing?
- N/A

## Anything else?
- N/A